### PR TITLE
Asciidoc: bugfix, Add an introduciton, change Alternative to Shipdriver

### DIFF
--- a/manual/modules/ROOT/pages/Alternative-Workflow.adoc
+++ b/manual/modules/ROOT/pages/Alternative-Workflow.adoc
@@ -1,4 +1,4 @@
-== Alternative Workflow for Managed Plugins
+== Shipdriver Workflow for Managed Plugins
 
 == Cloud Services
 

--- a/manual/modules/ROOT/pages/Appveyor.adoc
+++ b/manual/modules/ROOT/pages/Appveyor.adoc
@@ -16,4 +16,4 @@ image:3.appveyor.jpg[]
 
 image:4.appveyor.jpg[]
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/CircleCI.adoc
+++ b/manual/modules/ROOT/pages/CircleCI.adoc
@@ -33,4 +33,4 @@ image:6.circleci.jpg[]
 Circleci requires user to manually request a MacOS builder before it can
 be used. This process has been working flawlessly.
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Cloud-Service-Changes.adoc
+++ b/manual/modules/ROOT/pages/Cloud-Service-Changes.adoc
@@ -5,7 +5,7 @@ made the GitHub TideFinder repo can be updated with the file changes.
 
 == GitHub
 
-The alternative workflow simplifies the process of updating the plugin
+The shipdriver workflow simplifies the process of updating the plugin
 metadata files in 
 https://github.com/opencpn/plugins[OpenCPN/plugins].
 At the same time as installers for the TideFinder plugin are made the
@@ -100,4 +100,4 @@ image:build.errors/3.circleci.error.jpg[3.circleci.error.jpg]
 Again this is due to copying files on Windows. Once set as above the
 build will work.
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Cloudsmith.adoc
+++ b/manual/modules/ROOT/pages/Cloudsmith.adoc
@@ -94,4 +94,4 @@ image:10cloudsmith.jpg[10cloudsmith.jpg]
 copy/pasted to a file on your PC for use later.*
 image:11cloudsmith.jpg[11cloudsmith.jpg]
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/CodeChange.adoc
+++ b/manual/modules/ROOT/pages/CodeChange.adoc
@@ -52,4 +52,4 @@ TideFinder_pi::TideFinder_pi(void *ppimgr) :opencpn_plugin_116 (ppimgr)
 *Several source code files are involved in these changes, not just
 TideFinder_pi.cpp.*
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/GitHub.adoc
+++ b/manual/modules/ROOT/pages/GitHub.adoc
@@ -165,4 +165,4 @@ The new TideFinder metadata files have been added to your
 OpenCPN/plugins fork Beta branch. A PR results in updating the Beta
 catalog of OpenCPN/plugins, if it is accepted.
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Local-Build.adoc
+++ b/manual/modules/ROOT/pages/Local-Build.adoc
@@ -44,4 +44,4 @@ $ ci/circleci-build-macos
 After the initial run the build dependencies are in place and
 configured. Make for example the tarball using `cd build; make tarball`
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Metadata-Flow.adoc
+++ b/manual/modules/ROOT/pages/Metadata-Flow.adoc
@@ -22,4 +22,4 @@ README-git.md. The basic idea is that the developer has a clone of the
 plugins project, and that metadata from the builds is automatically
 pushed to this clone. See the file README-git.md for details.
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Plugin-Adaptation.adoc
+++ b/manual/modules/ROOT/pages/Plugin-Adaptation.adoc
@@ -89,4 +89,4 @@ substitutions.
 
 Just one substitution.
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Travis.adoc
+++ b/manual/modules/ROOT/pages/Travis.adoc
@@ -17,4 +17,4 @@ files.*
 
 image:3.travis.jpg[3.travis.jpg]
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/Useful-Stuff.adoc
+++ b/manual/modules/ROOT/pages/Useful-Stuff.adoc
@@ -47,4 +47,4 @@ mdc.SetTextForeground(m_text_color);
 //mdc.SetTextBackground(wxTRANSPARENT);`  ******* Removed this line to get openGL working in otcurrent_pi
 ....
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]

--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -77,8 +77,8 @@ assisted by testing the workflow. He has produced this guide to assist
 developers in making a managed plugin. Please report any errors or
 omissions using the issues tab of this GitHub repository.
 
-== The Alternative Workflow
+== The Shipdriver Workflow
 
-xref:Alternative-Workflow.adoc[The Alternative Workflow]
+xref:Alternative-Workflow.adoc[The Shipdriver Workflow]
 
 xref:Plugin-Dependencies.adoc[A Note on Plugin Dependencies]

--- a/manual/modules/ROOT/pages/index.adoc
+++ b/manual/modules/ROOT/pages/index.adoc
@@ -1,7 +1,22 @@
-== Managed Plugins for OpenCPN
+= Shipdriver Templates for OpenCPN Plugins
 
 :toc: right
 :experimental:
+
+==  Templates at a glance
+
+The shipdriver templates is a set of buildsystem templates which
+can be applied to any OpenCPN plugin. The templates provide
+
+* Generation of tarballs which can be used by the plugin installer
+* Uploading of tarballs to Cloudsmith
+* Generation of XML metadata with correct download urls and tarball chacksum
+* Support for making PRs to the plugins project by committing metadata
+  automatically into git.
+* Well-defined local builds of tarballs which can be imported
+
+The following guide illustrates how these templates can be applied 
+from scratch to a plugin.
 
 This guide should be read alongside the README files in the
 https://github.com/Rasbats/ShipDriver_pi[ShipDriver repository].

--- a/manual/site.yml
+++ b/manual/site.yml
@@ -6,7 +6,7 @@ content:
   sources:
   - url: ../
     branches: HEAD
-    start_path: docs/
+    start_path: manual/
 
 ui:
   output_dir: assets


### PR DESCRIPTION
Having the documentation in the development manual context creates a need for a more general overview and also to describe the workflow as 'Shipdriver'  rather than 'Alternatve' (alternative to what one might wonder).