### PR TITLE
Git push

### DIFF
--- a/manual/modules/ROOT/pages/InstallConfigure/Catalog-Github-Integration.adoc
+++ b/manual/modules/ROOT/pages/InstallConfigure/Catalog-Github-Integration.adoc
@@ -23,15 +23,14 @@ on Github.
 To enable this support which copies metadata from TideFinder to the
 OpenCPN/plugins fork:
 
-. Preparations:
-* Windows users should use git-bash. Nevertheless, using git-bash and invoking the python
-scripts used here does not work out of the box. In git-bash, you must use the command
-`alias python='winpty python.exe'` first, as a temporary work around before taking
-more actions. If you don't you will not be prompted for a password. See the https://stackoverflow.com/questions/32597209/[Stack overflow
-question] for more info
+. Preparations: [[Preparations]]
+* Windows users are best off using git-bash. However, invoking the python
+scripts used here does not work out of the box. In git-bash, use the command
+`alias python='winpty python.exe'` as a temporary work around before taking
+more actions. See the https://stackoverflow.com/questions/32597209/[Stack overflow
+question] for more info including a more permanent fix.
 * In the OpenCPN/plugins fork, make sure there is a remote named _upstream_.
 A oneliner fixes this:
-
 
     $ git ls-remote --exit-code upstream &>/dev/null || \
         git remote add upstream https://github.com/OpenCPN/plugins.git
@@ -60,39 +59,41 @@ $ git push -f origin auto:auto ④
 ③ Create a new branch on top of master or Beta +
 ④ Unconditionally overwrite the github branch
 +
-
-. _Steps 3-6 are also part of the xref::InstallConfigure/GithubPreps.adoc[
+. _Steps 3-7 are also part of the xref::InstallConfigure/GithubPreps.adoc[
 Initial setup  workflow] and may thus already be completed_. +
 [[new-credentials]]
-
-in the TideFinder Local Replository (or your plugins repo) 
-Run _python ci/new-credentials_ . The script
-will ask for the ssh url to your plugins fork repo and a secret
-password. If there is no prompt for a password, stop and start over.
-The script must complete with a password entry to create <user>.enc and 
-<user>.pub files in the build-dpe folder, which secures your private key.
-
-The ssh url, something like `git@github.com:Rasbats/plugins.git`,
-can be found in the Github UI:
++
+You will need the ssh url to your OpenCPN/plugins fork, something like
+`git@github.com:Rasbats/plugins.git`. This can be found in the Github UI:
 +
 image::github/1.plugins.jpg[1.plugins.jpg]
 +
 Or, in the OpenCPN/plugins fork, on the command line using +
 `git config --get remote.origin.url`
-
++
+. Run _python ci/new-credentials_ in the TideFinder repo. The script
+will ask for the ssh url to your plugins fork repo and a secret
+password.
++
+NOTE: If the script does not complete on Windows, check that the
+`alias python= ...` command mentioned in xref:#Preparations[Preparations]
+has been executed.
++
 . Dont forget the password...
-. The script will create an encrypted private + a public key in the
-TideFinder _build-deps_ directory. Commit and push these to Github:
+. The script will create an encrypted private + a public key named
+_username.enc_ and _username.pub_ in the TideFinder _build-deps_ directory.
+Commit and push these keys to Github:
 +
 ....
-$ git add build-deps/*.enc build-deps/*.pub
-$ git commit -m "Add git deployment key."
-$ git push origin master:master
+   $ git add build-deps/*.enc build-deps/*.pub
+   $ git commit -m "Add git deployment key."
+   $ git push origin master:master
 ....
 
-. In your forked "plugins" repository Register the new public key (displayed by new-credentials) as a
-deployment key with write permissions (Allow write access) on your
-github OpenCPN/plugins fork repo (in Settings | Deploy keys):
+. In your forked "plugins" repository Register the new public key (displayed
+by new-credentials) as a
+deployment key with write permissions (Allow write access) on your github
+OpenCPN/plugins fork repo (in Settings | Deploy keys):
 +
 image:github/10.deploy.key.jpg[10.deploy.key.jpg]
 +

--- a/manual/modules/ROOT/pages/InstallConfigure/GithubPreps.adoc
+++ b/manual/modules/ROOT/pages/InstallConfigure/GithubPreps.adoc
@@ -12,7 +12,7 @@ authorises the connection with Github.
 
 == Providing the link to your OpenCPN/plugins fork
 
-Run steps 3-6 in the
+Run steps 3-7 in the
 xref::InstallConfigure/Catalog-Github-Integration.adoc#new-credentials[
 Metadata Push Page].
 Eventually, this ends up in a SSH-based url and

--- a/manual/modules/ROOT/pages/Plugin-Adaptation.adoc
+++ b/manual/modules/ROOT/pages/Plugin-Adaptation.adoc
@@ -22,7 +22,7 @@ xref:UPDATE_TEMPLATES.adoc[UPDATE_TEMPLATES.md].
 
 The script will install all files required in TideFinder except
 as noted below. Note that script is normally used to update to
-a tag like sd3.0.0
+from a tag like sd3.0.0
 
 === README.md and COPYING
 
@@ -51,7 +51,8 @@ updating to sd3.0.0
 This file needs to be modified, most of the required items will be available
 in CMakeLists.txt. After having modified _Plugin.cmake_ to match TideFinder
 checkout the generic, template CMakeLists.txt using
-`git checkout shipdriver/master CMakeLists.txt`.
+`git checkout sd3.0.0 CMakeLists.txt`, assuming update-templates used the
+sd3.0.0 tag.
 
 This will overwrite the existing _CMakeLists.txt_, but after all it is in the
 git history. Commit the two files.


### PR DESCRIPTION
    Metadata push: Clarify steps, note on Windows script deadlock.
    
    Divide the sometimes problematic step to run new-credentials
    into two.
    
    Remove the too strict language about the python alias. It
    is not strictly necessary, the stackoverflow question describes
    how to make a permanent fix to avoid it. Likewise, that
    Windows users "should" use git-bash is a little too strong.
    For those who are really motivated it's possible to use
    CMD.
    
    Shorten the too lengthy explanation that "script must complete".
    All scripts in a workflow must complete, this is implied. Focus
    on how to handle when it not completes on Windows in a
    prominent note.

