### PR TITLE
manual: antora.yml: Use default version a k a '~'

### DIFF
--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -1,6 +1,6 @@
 name: AlternativeWorkflow
 title: Shipdriver Managed Workflow for the OpenCPN plugins
-version: master
+version: ~
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
As mentioned in zulip. Corresponding change needs to be done to the plugins.